### PR TITLE
Fix extract keymap in docs

### DIFF
--- a/doc/zettel.txt
+++ b/doc/zettel.txt
@@ -85,7 +85,7 @@ These are **suggested** defaults; configure in your own `keymap.set`:
     <leader>zj   Open daily journal
     <leader>zt   Search titles
     <leader>zf   Full-text search
-    <leader>ne   Extract selection to new note (visual mode)
+    <leader>ze   Extract selection to new note (visual mode)
 <
 
 ==============================================================================


### PR DESCRIPTION
## Summary
- fix docs to use `<leader>ze` for extracting a selection to a new note

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887b9f752948331b15d1f4ed6b9c19e